### PR TITLE
release 1.4.5

### DIFF
--- a/ci/e2e-via-ssh-deployment-playbook.yaml
+++ b/ci/e2e-via-ssh-deployment-playbook.yaml
@@ -148,7 +148,7 @@
           infraOperator:
             chart:
               git: https://github.com/th2-net/infra-operator-tpl.git
-              ref: v0.3.3
+              ref: v0.3.2
               path: ./
         values_files:
           "{{ playbook_dir }}/../example-values/service.values.yaml"

--- a/ci/e2e-via-ssh-deployment-playbook.yaml
+++ b/ci/e2e-via-ssh-deployment-playbook.yaml
@@ -145,11 +145,11 @@
           infraMgr:
             git:
               repository: git@github.com:th2-net/e2e-test-schema.git
-          infraOperator:
-            chart:
-              git: https://github.com/th2-net/infra-operator-tpl.git
-              ref: release-v0.3.2
-              path: ./
+#           infraOperator:
+#             chart:
+#               git: https://github.com/th2-net/infra-operator-tpl.git
+#               ref: release-v0.3.2
+#               path: ./
         values_files:
           "{{ playbook_dir }}/../example-values/service.values.yaml"
           # - ./secrets.yaml

--- a/ci/e2e-via-ssh-deployment-playbook.yaml
+++ b/ci/e2e-via-ssh-deployment-playbook.yaml
@@ -148,7 +148,7 @@
           infraOperator:
             chart:
               git: https://github.com/th2-net/infra-operator-tpl.git
-              ref: v0.3.2
+              ref: release-v0.3.2
               path: ./
         values_files:
           "{{ playbook_dir }}/../example-values/service.values.yaml"

--- a/ci/e2e-via-ssh-deployment-playbook.yaml
+++ b/ci/e2e-via-ssh-deployment-playbook.yaml
@@ -145,11 +145,11 @@
           infraMgr:
             git:
               repository: git@github.com:th2-net/e2e-test-schema.git
-          # infraOperator:
-          #   chart:
-          #     git: https://github.com/th2-net/infra-operator-tpl.git
-          #     ref: v0.2.0
-          #     path: ./
+          infraOperator:
+            chart:
+              git: https://github.com/th2-net/infra-operator-tpl.git
+              ref: v0.3.3
+              path: ./
         values_files:
           "{{ playbook_dir }}/../example-values/service.values.yaml"
           # - ./secrets.yaml

--- a/th2-service/values.yaml
+++ b/th2-service/values.yaml
@@ -33,7 +33,7 @@ infraOperator:
   config:
     chart:
       repository: https://th2-net.github.io
-      version: 0.3.1
+      version: 0.3.2
       name: infra-operator-tpl
     namespacePrefixes: 
     - "schema-"


### PR DESCRIPTION
Now prometheus can be disabled by any value except "true"
Example for disabling:

prometheus:
  enabled: "false" <-- not equal to "true"

prometheus:
  enabled: "lkdjsll403" <-- not equal to "true"