### PR TITLE
[Th2-3358] Infra-mgr -> Github stop accepting ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ $ kubectl config set-context --current --namespace=service
 ```
 $ ssh-keygen -t rsa -m pem -f ./infra-mgr-rsa.key
 ``` 
-* [Add a new SSH key to your GitHub account](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account)
+* [Add a new deploy key to your schema repository on GitHub ](https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys)
 * Create infra-mgr secret from the private key:
 ```
-$ kubectl -n service create secret generic infra-mgr --from-file=infra-mgr=./infra-mgr-rsa.key
+$ kubectl -n service create secret generic infra-mgr --from-file=id_rsa=./infra-mgr-rsa.key
 ```
 
 ### Set the repository with schema configuration

--- a/ci/e2e-via-ssh-deployment-playbook.yaml
+++ b/ci/e2e-via-ssh-deployment-playbook.yaml
@@ -95,7 +95,7 @@
             name: infra-mgr
             namespace: "{{ infra_namespace }}"
           data:
-            infra-mgr: "{{ lookup('env','E2E_PRIVATE_KEY') | b64encode }}"
+            id_rsa: "{{ lookup('env','E2E_PRIVATE_KEY') | b64encode }}"
 
     - name: Create git-chart-creds secret
       kubernetes.core.k8s:

--- a/example-values/service.values.yaml
+++ b/example-values/service.values.yaml
@@ -17,3 +17,4 @@ rabbitmq:
 cassandra:
   internal: false
   host: <cassandra-host>
+

--- a/th2-service/README.md
+++ b/th2-service/README.md
@@ -34,13 +34,12 @@ th2 service Helm chart
 | infraMgr.cassandra.secret | string | `"cassandra"` |  |
 | infraMgr.git.httpAuthPassword | string | `""` |  |
 | infraMgr.git.httpAuthUsername | string | `""` |  |
-| infraMgr.git.privateKeyFileSecret | string | `"infra-mgr"` |  |
 | infraMgr.git.repository | string | `"git@github.com:th2-net/th2-demo-configuration.git"` |  |
 | infraMgr.git.repositoryLocalCache | string | `"/home/service/repository"` |  |
-| infraMgr.git.secretMountPath | string | `"/home/service/keys"` |  |
 | infraMgr.git.secretName | string | `"infra-mgr"` |  |
+| infraMgr.git.sshDir | string | `"/home/service/keys"` |  |
 | infraMgr.image.repository | string | `"ghcr.io/th2-net/th2-infra-mgr"` |  |
-| infraMgr.image.tag | string | `"1.2.11"` |  |
+| infraMgr.image.tag | string | `"1.2.13"` |  |
 | infraMgr.kubernetes.configMaps.cassandra | string | `"cradle"` |  |
 | infraMgr.kubernetes.configMaps.cassandra-ext | string | `"cradle-external"` |  |
 | infraMgr.kubernetes.configMaps.logging | string | `"logging-config-template"` |  |
@@ -111,7 +110,7 @@ th2 service Helm chart
 | rabbitmq.rabbitmqErlangCookie | string | `""` |  |
 | rabbitmq.rabbitmqExchange | string | `"th2-exchange"` |  |
 | rabbitmq.rabbitmqMemoryHighWatermark | string | `"1024MB"` |  |
-| rabbitmq.rabbitmqPassword | string | `""` | will be generated if empty |
+| rabbitmq.rabbitmqPassword | string | `""` | Will be generated if empty |
 | rabbitmq.rabbitmqPrometheusPlugin.enabled | bool | `true` |  |
 | rabbitmq.rabbitmqUsername | string | `"th2"` |  |
 | rabbitmq.rabbitmqVhost | string | `"th2"` |  |

--- a/th2-service/templates/configs/_infraMgr-config.yaml
+++ b/th2-service/templates/configs/_infraMgr-config.yaml
@@ -2,6 +2,17 @@
 Generating configMap for k8
 */}}
 {{- define "infraMgr-config" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-config
+  annotations:
+  {{- include "common-annotations" . | nindent 4  }}
+data:
+  config: |
+    StrictHostKeyChecking no
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -17,7 +28,7 @@ data:
     git:
       remoteRepository: {{ .Values.infraMgr.git.repository }}
       localRepositoryRoot: {{ .Values.infraMgr.git.repositoryLocalCache }}
-      sshDir: {{ .Values.infraMgr.git.secretMountPath }}
+      sshDir: {{ .Values.infraMgr.git.sshDir }}
       httpAuthUsername: "${HTTPS_AUTH_USERNAME}"
       httpAuthPassword: "${HTTPS_AUTH_PASSWORD}"
 

--- a/th2-service/templates/configs/_infraMgr-config.yaml
+++ b/th2-service/templates/configs/_infraMgr-config.yaml
@@ -17,8 +17,7 @@ data:
     git:
       remoteRepository: {{ .Values.infraMgr.git.repository }}
       localRepositoryRoot: {{ .Values.infraMgr.git.repositoryLocalCache }}
-      privateKeyFile: {{ .Values.infraMgr.git.secretMountPath }}/{{ .Values.infraMgr.git.privateKeyFileSecret }}
-      ignoreInsecureHosts: true
+      sshDir: {{ .Values.infraMgr.git.secretMountPath }}
       httpAuthUsername: "${HTTPS_AUTH_USERNAME}"
       httpAuthPassword: "${HTTPS_AUTH_PASSWORD}"
 

--- a/th2-service/templates/infra-mgr.yaml
+++ b/th2-service/templates/infra-mgr.yaml
@@ -2,6 +2,16 @@
 ---
 {{ include "infra-mgr-service" . }}
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ssh-config
+  annotations:
+  {{- include "common-annotations" . | nindent 4  }}
+data:
+  config: |
+    StrictHostKeyChecking no
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -63,8 +73,12 @@ spec:
                 key: httpAuthPassword
       volumes:
       - name : secrets
-        secret:
-          secretName: {{ .Values.infraMgr.git.secretName }}
+        projected:
+          sources:
+          - secret:
+              name: {{ .Values.infraMgr.git.secretName }}
+          - configMap:
+              name: ssh-config
       - name: configs
         projected:
           sources:

--- a/th2-service/templates/infra-mgr.yaml
+++ b/th2-service/templates/infra-mgr.yaml
@@ -2,16 +2,6 @@
 ---
 {{ include "infra-mgr-service" . }}
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ssh-config
-  annotations:
-  {{- include "common-annotations" . | nindent 4  }}
-data:
-  config: |
-    StrictHostKeyChecking no
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,7 +47,7 @@ spec:
             mountPath: /home/service/config/
           - name: secrets
             readOnly: true
-            mountPath: {{ .Values.infraMgr.git.secretMountPath }}
+            mountPath: {{ .Values.infraMgr.git.sshDir }}
         env:
           - name: JAVA_TOOL_OPTIONS
             value: -XX:MaxHeapSize=2048m

--- a/th2-service/values.yaml
+++ b/th2-service/values.yaml
@@ -83,7 +83,7 @@ infraMgr:
     enabled: true
   image:
     repository: ghcr.io/th2-net/th2-infra-mgr
-    tag: 1.2.11
+    tag: 1.2.13
   git:
     secretName: infra-mgr
     privateKeyFileSecret: infra-mgr

--- a/th2-service/values.yaml
+++ b/th2-service/values.yaml
@@ -86,8 +86,7 @@ infraMgr:
     tag: 1.2.13
   git:
     secretName: infra-mgr
-    privateKeyFileSecret: infra-mgr
-    secretMountPath: /home/service/keys
+    sshDir: /home/service/keys
     repository: git@github.com:th2-net/th2-demo-configuration.git
     repositoryLocalCache: /home/service/repository
     httpAuthUsername: "" #should be stored in secret th2-git-access-schemas


### PR DESCRIPTION
ssh keys generated with command from th2-infra guide have been stoppped accepting since 16 march 2022 if they were uploaded to github after this date.

Error in infra-mgr:

16 Mar 2022 16:45:52,665 ERROR  [main           ] com.exactpro.th2.inframgr.k8s.K8sSynchronization - Exception fetching branch list from repository

org.eclipse.jgit.api.errors.TransportException: git@github.com:th2-net/e2e-test-schema.git: ERROR: You're using an RSA key with SHA-1, which is no longer allowed. Please use a newer client or a different key type.

Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.