### PR TITLE
New infra-mgr and infra-operator versions

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,7 +73,7 @@ infraOperator:
     port: 9752
   image:
     repository: ghcr.io/th2-net/th2-infra-operator
-    tag: 3.6.3-infra-1.8-2225559948
+    tag: 3.6.4
   config:
     chart:
       repository: http://infra-repo:8080
@@ -113,7 +113,7 @@ infraMgr:
     port: 9752
   image:
     repository: ghcr.io/th2-net/th2-infra-mgr
-    tag: 1.7.14-infra-1.8.0-2239927561
+    tag: 1.7.18
   git:
     secretName: infra-mgr
     sshDir: /home/service/keys


### PR DESCRIPTION
infra-mgr:1.7.18: Changes about validating schemas and canceled unnecessary sessions with cassandra.
infra-operator:3.6.4: New rabbitmq library and changes with logging.