### PR TITLE
[TH2-4354] rename chartCfg to chartConfig in CRDs

### DIFF
--- a/chart/crds/th2-box-crd.yaml
+++ b/chart/crds/th2-box-crd.yaml
@@ -69,7 +69,7 @@ spec:
                 type: object
                 description: section for extended settings
                 properties:
-                  chartCfg:
+                  chartConfig:
                     description: specifies which charts to use for rolling out infra
                     properties:
                       path:

--- a/chart/crds/th2-core-box-crd.yaml
+++ b/chart/crds/th2-core-box-crd.yaml
@@ -68,7 +68,7 @@ spec:
                 type: object
                 description: section for extended settings
                 properties:
-                  chartCfg:
+                  chartConfig:
                     description: specifies which charts to use for rolling out infra
                     properties:
                       path:

--- a/chart/crds/th2-estore-crd.yaml
+++ b/chart/crds/th2-estore-crd.yaml
@@ -66,7 +66,7 @@ spec:
                 type: object
                 description: section for extended settings
                 properties:
-                  chartCfg:
+                  chartConfig:
                     description: specifies which charts to use for rolling out infra
                     properties:
                       path:

--- a/chart/crds/th2-mstore-crd.yaml
+++ b/chart/crds/th2-mstore-crd.yaml
@@ -66,7 +66,7 @@ spec:
                 type: object
                 description: section for extended settings
                 properties:
-                  chartCfg:
+                  chartConfig:
                     description: specifies which charts to use for rolling out infra
                     properties:
                       path:


### PR DESCRIPTION
The change affects `box`, `core-box`, `mstore` and `estore` CRDs.